### PR TITLE
Initialize the power down seconds counter.

### DIFF
--- a/examples/Sensor_TX_ATtiny85_2Pin/Sensor_TX_ATtiny85_2Pin.ino
+++ b/examples/Sensor_TX_ATtiny85_2Pin/Sensor_TX_ATtiny85_2Pin.ino
@@ -303,7 +303,7 @@ void sendMessage(String msg)
 
 void sleep(uint32_t seconds)
 {
-    uint32_t totalPowerDownSeconds;
+    uint32_t totalPowerDownSeconds = 0;
     uint8_t canSleep8Seconds;
 
     _radio.powerDown();            // Put the radio into a low power state.


### PR DESCRIPTION
The value of `totalPowerDownSeconds` must be initialized before it's being checked against the requested sleep seconds in the while loop condition.