### PR TITLE
Public function for scanning channel traffic

### DIFF
--- a/examples/ChannelScanner/ChannelScanner.ino
+++ b/examples/ChannelScanner/ChannelScanner.ino
@@ -48,7 +48,23 @@ void setup()
 
     for (uint8_t channel = 0; channel <= NRFLite::MAX_NRF_CHANNEL; channel++)
     {
-        _radio.printChannel(channel);
+        uint8_t signalStrength = _radio.scanChannel(channel);
+
+        // Build the message about the channel, e.g. 'Channel 125 XXXXXXXXX'
+        String channelMsg = "Channel ";
+
+        if (channel < 10) { channelMsg += "  "; }
+        else if (channel < 100) { channelMsg += " "; }
+        channelMsg += channel;
+        channelMsg += "  ";
+
+        while (signalStrength--)
+        {
+            channelMsg += "X";
+        }
+
+        // Print the channel message.
+        Serial.println(channelMsg);
 
 #if defined(ESP8266) || defined(ESP32)
         yield();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NRFLite
-version=2.4.4
+version=3.0.0
 author=Dave Parson <dparson55@hotmail.com>
 maintainer=Dave Parson <dparson55@hotmail.com>
 sentence=nRF24L01+ library requiring very little code along with YouTube videos showing all available features.

--- a/src/NRFLite.cpp
+++ b/src/NRFLite.cpp
@@ -304,28 +304,6 @@ void NRFLite::printDetails()
     debugln(msg);
 }
 
-void NRFLite::printChannel(uint8_t channel)
-{
-    // Take measurements.
-    uint8_t signalStrength = scanChannel(channel);
-
-    // Build the message about the channel, e.g. 'Channel 125 XXXXXXXXX'
-    String channelMsg = "Channel ";
-
-    if      (channel < 10 ) { channelMsg += "  "; }
-    else if (channel < 100) { channelMsg += " ";  }
-    channelMsg += channel;
-    channelMsg += "  ";
-
-    while (signalStrength--)
-    {
-        channelMsg += "X";
-    }
-
-    // Print the channel message.
-    debugln(channelMsg);
-}
-
 uint8_t NRFLite::scanChannel(uint8_t channel)
 {
     uint8_t strength = 0;
@@ -337,7 +315,8 @@ uint8_t NRFLite::scanChannel(uint8_t channel)
     writeRegister(RF_CH, channel);
 
     // Take a bunch of measurements.
-    for (uint8_t measurementCount = 0; measurementCount < 200; measurementCount++)
+    uint8_t measurementCount = 255;
+    do
     {
         // Put the radio into RX mode and wait a little time for a signal to be received.
         digitalWrite(_cePin, HIGH);
@@ -349,7 +328,8 @@ uint8_t NRFLite::scanChannel(uint8_t channel)
         {
             strength++;
         }
-    }
+    } while (measurementCount--);
+    
     return strength;
 }
 

--- a/src/NRFLite.cpp
+++ b/src/NRFLite.cpp
@@ -306,31 +306,12 @@ void NRFLite::printDetails()
 
 void NRFLite::printChannel(uint8_t channel)
 {
-    // Put radio into Standby-I mode.
-    digitalWrite(_cePin, LOW);
-
-    // Set the channel.
-    writeRegister(RF_CH, channel);
-
     // Take measurements.
-    uint8_t signalStrength = 0;
-    for (uint8_t measurementCount = 0; measurementCount < 200; measurementCount++)
-    {
-        // Put the radio into RX mode and wait a little time for a signal to be received.
-        digitalWrite(_cePin, HIGH);
-        delayMicroseconds(400);
-        digitalWrite(_cePin, LOW);
-
-        uint8_t signalWasReceived = readRegister(CD);
-        if (signalWasReceived)
-        {
-            signalStrength++;
-        }
-    }
+    uint8_t signalStrength = scanChannel(channel);
 
     // Build the message about the channel, e.g. 'Channel 125 XXXXXXXXX'
     String channelMsg = "Channel ";
-    
+
     if      (channel < 10 ) { channelMsg += "  "; }
     else if (channel < 100) { channelMsg += " ";  }
     channelMsg += channel;
@@ -343,6 +324,33 @@ void NRFLite::printChannel(uint8_t channel)
 
     // Print the channel message.
     debugln(channelMsg);
+}
+
+uint8_t NRFLite::scanChannel(uint8_t channel)
+{
+    uint8_t strength = 0;
+
+    // Put radio into Standby-I mode.
+    digitalWrite(_cePin, LOW);
+
+    // Set the channel.
+    writeRegister(RF_CH, channel);
+
+    // Take a bunch of measurements.
+    for (uint8_t measurementCount = 0; measurementCount < 200; measurementCount++)
+    {
+        // Put the radio into RX mode and wait a little time for a signal to be received.
+        digitalWrite(_cePin, HIGH);
+        delayMicroseconds(400);
+        digitalWrite(_cePin, LOW);
+
+        uint8_t signalWasReceived = readRegister(CD);
+        if (signalWasReceived)
+        {
+            strength++;
+        }
+    }
+    return strength;
 }
 
 /////////////////////

--- a/src/NRFLite.h
+++ b/src/NRFLite.h
@@ -40,6 +40,7 @@ class NRFLite {
     void powerDown();
     void printDetails();
     void printChannel(uint8_t channel);
+    uint8_t scanChannel(uint8_t channel);
 
     // Methods for transmitters.
     // send = Sends a data packet and waits for success or failure.  The default REQUIRE_ACK sendType causes the radio

--- a/src/NRFLite.h
+++ b/src/NRFLite.h
@@ -31,7 +31,8 @@ class NRFLite {
     // readData   = Loads a received data packet or acknowledgment data packet into the specified data parameter.
     // powerDown  = Power down the radio.  Turn the radio back on by calling one of the 'hasData' or 'send' methods.
     // printDetails = Prints many of the radio registers.  Requires a serial object in the constructor, e.g. NRFLite _radio(Serial);
-    // printChannel = Prints a simple graph showing any received signals across the channel.  Requires a serial object in the constructor.
+    // scanChannel  = Returns 0-255 to indicate the strength of any existing signal on a channel.  Radio communication will
+    //                work best on channels with no existing signals, meaning a 0 is returned.
     uint8_t init(uint8_t radioId, uint8_t cePin, uint8_t csnPin, Bitrates bitrate = BITRATE2MBPS, uint8_t channel = 100, uint8_t callSpiBegin = 1);
 #if defined(__AVR__)
     uint8_t initTwoPin(uint8_t radioId, uint8_t momiPin, uint8_t sckPin, Bitrates bitrate = BITRATE2MBPS, uint8_t channel = 100);
@@ -39,7 +40,6 @@ class NRFLite {
     void readData(void *data);
     void powerDown();
     void printDetails();
-    void printChannel(uint8_t channel);
     uint8_t scanChannel(uint8_t channel);
 
     // Methods for transmitters.


### PR DESCRIPTION
Adds `uint8_t scanChannel(uint8_t channel)` as a public method. This method returns a value up to 200 to indicate the signal strength and/or congestion on the channel, similar to how `printChannel` works. Allows use of scanning channels without needing a Serial monitor to check the results.
`printChannel` updated to use this new function.