### PR TITLE
Measurement count for scanChannel

### DIFF
--- a/src/NRFLite.cpp
+++ b/src/NRFLite.cpp
@@ -304,7 +304,7 @@ void NRFLite::printDetails()
     debugln(msg);
 }
 
-uint8_t NRFLite::scanChannel(uint8_t channel)
+uint8_t NRFLite::scanChannel(uint8_t channel, uint8_t measurementCount /*= 255*/)
 {
     uint8_t strength = 0;
 
@@ -315,7 +315,6 @@ uint8_t NRFLite::scanChannel(uint8_t channel)
     writeRegister(RF_CH, channel);
 
     // Take a bunch of measurements.
-    uint8_t measurementCount = 255;
     do
     {
         // Put the radio into RX mode and wait a little time for a signal to be received.

--- a/src/NRFLite.h
+++ b/src/NRFLite.h
@@ -31,7 +31,7 @@ class NRFLite {
     // readData   = Loads a received data packet or acknowledgment data packet into the specified data parameter.
     // powerDown  = Power down the radio.  Turn the radio back on by calling one of the 'hasData' or 'send' methods.
     // printDetails = Prints many of the radio registers.  Requires a serial object in the constructor, e.g. NRFLite _radio(Serial);
-    // scanChannel  = Returns 0-255 to indicate the strength of any existing signal on a channel.  Radio communication will
+    // scanChannel  = Returns 0-measurementCount to indicate the strength of any existing signal on a channel.  Radio communication will
     //                work best on channels with no existing signals, meaning a 0 is returned.
     uint8_t init(uint8_t radioId, uint8_t cePin, uint8_t csnPin, Bitrates bitrate = BITRATE2MBPS, uint8_t channel = 100, uint8_t callSpiBegin = 1);
 #if defined(__AVR__)
@@ -40,7 +40,7 @@ class NRFLite {
     void readData(void *data);
     void powerDown();
     void printDetails();
-    uint8_t scanChannel(uint8_t channel);
+    uint8_t scanChannel(uint8_t channel, uint8_t measurementCount = 255);
 
     // Methods for transmitters.
     // send = Sends a data packet and waits for success or failure.  The default REQUIRE_ACK sendType causes the radio


### PR DESCRIPTION
Doing 255 channels reads takes some time, so I've exposed `measurementCount` as a parameter for `scanChannel` to allow a user to reduce this.

~`setChannel` and `setRadioId` use the same setup as in the `init` function to set those properties.~